### PR TITLE
Test filtering of notes and events within range

### DIFF
--- a/miditoolkit/midi/parser.py
+++ b/miditoolkit/midi/parser.py
@@ -634,9 +634,13 @@ def _check_note_within_range(note, st, ed, shift=True):
     if shift:
         tmp_st -= st
         tmp_ed -= st
-    note.start = int(tmp_st)
-    note.end = int(tmp_ed)
-    return note
+
+    return Note(
+        velocity=note.velocity,
+        pitch=note.pitch,
+        start=tmp_st,
+        end=tmp_ed
+    )
 
 
 def _include_meta_events_within_range(events, st, ed, shift=True, front=True):

--- a/miditoolkit/midi/parser.py
+++ b/miditoolkit/midi/parser.py
@@ -659,7 +659,7 @@ def _include_meta_events_within_range(events, st, ed, shift=True, front=True):
         if event.time < st:
             break
         if event.time < ed:
-            proc_events.append(event)
+            proc_events.append(deepcopy(event))
         i -= 1
 
     # if the first tick has no event, add the previous one
@@ -667,7 +667,7 @@ def _include_meta_events_within_range(events, st, ed, shift=True, front=True):
         if not proc_events:
             proc_events = [events[i]]
         elif proc_events[-1].time != st:
-            proc_events.append(events[i])
+            proc_events.append(deepcopy(events[i]))
         else:
             pass
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,197 @@
+from miditoolkit.midi.parser import _check_note_within_range
+from miditoolkit.midi.containers import Note
+from copy import deepcopy
+
+import pytest
+
+
+def assert_notes_equal(note1, note2):
+    assert note1.velocity == note2.velocity
+    assert note1.pitch == note2.pitch
+    assert note1.start == note2.start
+    assert note1.end == note2.end
+
+
+@pytest.fixture
+def start_tick():
+    return 100
+
+
+@pytest.fixture
+def end_tick():
+    return 200
+
+
+@pytest.fixture
+def velocity():
+    return 100
+
+
+@pytest.fixture
+def pitch():
+    return 60
+
+
+@pytest.fixture
+def note(start_tick, end_tick, velocity, pitch):
+    return Note(
+        velocity=velocity,
+        pitch=pitch,
+        start=start_tick,
+        end=end_tick,
+    )
+
+
+def test__check_note_within_range_with_shift(
+    note, start_tick, end_tick, velocity, pitch
+):
+    """Note is entirely within range"""
+    orig_note = deepcopy(note)
+
+    range_start_tick = note.start - 10
+    range_end_tick = note.end + 10
+
+    shift = True
+    offset = start_tick - range_start_tick
+
+    exp = Note(
+        velocity=velocity,
+        pitch=pitch,
+        start=offset,
+        end=offset + end_tick - start_tick,
+    )
+
+    got = _check_note_within_range(
+        note=note,
+        st=range_start_tick,
+        ed=range_end_tick,
+        shift=shift,
+    )
+    assert_notes_equal(got, exp)
+    # note should be unchanged
+    assert_notes_equal(note, orig_note)
+
+
+def test__check_note_within_range_note_starts_before_range(
+    note, end_tick, velocity, pitch
+):
+    """Note starts before range, ends within range"""
+    orig_note = deepcopy(note)
+
+    range_start_tick = note.start + 10
+    range_end_tick = note.end + 10
+
+    shift = True
+
+    exp = Note(
+        velocity=velocity,
+        pitch=pitch,
+        start=0,
+        end=end_tick - range_start_tick,
+    )
+
+    got = _check_note_within_range(
+        note=note,
+        st=range_start_tick,
+        ed=range_end_tick,
+        shift=shift,
+    )
+    assert_notes_equal(got, exp)
+    # note should be unchanged
+    assert_notes_equal(note, orig_note)
+
+
+def test__check_note_within_range_note_ends_after_range(
+    note, start_tick, velocity, pitch
+):
+    """Note starts within range, ends after range"""
+    orig_note = deepcopy(note)
+
+    range_start_tick = note.start - 10
+    range_end_tick = note.end - 10
+
+    shift = True
+    offset = start_tick - range_start_tick
+
+    exp = Note(
+        velocity=velocity,
+        pitch=pitch,
+        start=offset,
+        end=range_end_tick - range_start_tick,
+    )
+
+    got = _check_note_within_range(
+        note=note,
+        st=range_start_tick,
+        ed=range_end_tick,
+        shift=shift,
+    )
+    assert_notes_equal(got, exp)
+    # note should be unchanged
+    assert_notes_equal(note, orig_note)
+
+
+def test__check_note_within_range_note_starts_after_ends_after_range(note):
+    """Note starts after range, ends after range"""
+    orig_note = deepcopy(note)
+
+    range_start_tick = note.start + 10
+    range_end_tick = note.end - 10
+
+    shift = True
+
+    exp = None
+
+    got = _check_note_within_range(
+        note=note,
+        st=10,
+        ed=range_end_tick - range_start_tick,
+        shift=shift,
+    )
+    assert got is exp
+    # note should be unchanged
+    assert_notes_equal(note, orig_note)
+
+
+def test__check_note_within_range_note_contains_range(note, velocity, pitch):
+    """Note starts before range and ends after range"""
+    orig_note = deepcopy(note)
+
+    range_start_tick = note.start + 10
+    range_end_tick = note.end - 10
+
+    shift = True
+
+    exp = Note(
+        velocity=velocity,
+        pitch=pitch,
+        start=0,
+        end=range_end_tick - range_start_tick,
+    )
+
+    got = _check_note_within_range(
+        note=note,
+        st=range_start_tick,
+        ed=range_end_tick,
+        shift=shift,
+    )
+    assert_notes_equal(got, exp)
+    # note should be unchanged
+    assert_notes_equal(note, orig_note)
+
+
+def test__check_note_within_range_false(note):
+    for range_start_tick, range_end_tick in [
+        (0, 50),  # range before note
+        (300, 400),  # range after note
+    ]:
+        for shift in [True, False]:
+            got = _check_note_within_range(
+                note=note,
+                st=range_start_tick,
+                ed=range_end_tick,
+                shift=shift,
+            )
+            assert (
+                got is None
+            ), f"Failed for range: ({range_start_tick}, {range_end_tick})"


### PR DESCRIPTION
Adds tests to check that miditoolkit correctly filters events and notes within the desired range.

Note that if any part of a note is within the range, it is preserved.